### PR TITLE
Hotkeys for manual material selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,6 @@
     "node": "22.x"
   },
   "pnpm": {
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "esbuild"
-    ]
+    "onlyBuiltDependencies": ["@swc/core", "esbuild"]
   }
 }

--- a/src/pages/calculator/calculator.tsx
+++ b/src/pages/calculator/calculator.tsx
@@ -18,7 +18,7 @@ import { structures } from '../../utils/structures'
 import styles from './calculator.module.css'
 
 export function Calculator() {
-  const [materialType, setMaterialType] = useState<Material>(materials[0][1])
+  const [materialType, setMaterialType] = useState<Material>(materials[0].slug)
   const [provided, setProvided] = useState(0)
   const [required, setRequired] = useState(0)
   const [note, setNote] = useState('')
@@ -37,17 +37,9 @@ export function Calculator() {
 
   // Create materials array with hotkey information
   const materialsWithHotkeys = useMemo(() => {
-    const hotkeyMap: Record<Material, string> = {
-      ceramics: 'C',
-      chemicals: 'H',
-      chiral_crystals: 'I',
-      metals: 'M',
-      resins: 'R',
-      special_alloys: 'S',
-    }
-
     return materials.map(
-      ([label, value]) => [`${label} (${hotkeyMap[value]})`, value] as const,
+      ({ label, slug, hotkey }) =>
+        [`${label} (${hotkey.toUpperCase()})`, slug] as const,
     )
   }, [])
 
@@ -68,8 +60,8 @@ export function Calculator() {
       // Only handle hotkeys when not typing in text input fields or textareas
       if (
         event.target instanceof HTMLTextAreaElement ||
-        (event.target instanceof HTMLInputElement && 
-         event.target.type !== 'number')
+        (event.target instanceof HTMLInputElement &&
+          event.target.type !== 'number')
       ) {
         return
       }
@@ -81,16 +73,7 @@ export function Calculator() {
 
       const key = event.key.toLowerCase()
 
-      const materialMap: Record<string, Material> = {
-        c: 'ceramics',
-        h: 'chemicals',
-        i: 'chiral_crystals',
-        m: 'metals',
-        r: 'resins',
-        s: 'special_alloys',
-      }
-
-      const newMaterial = materialMap[key]
+      const newMaterial = materials.find(({ hotkey }) => hotkey === key)?.slug
       if (newMaterial) {
         setMaterialType(newMaterial)
         event.preventDefault()
@@ -108,7 +91,9 @@ export function Calculator() {
       return
     }
 
-    const materialTypeLabel = materials.find(([, b]) => b === materialType)?.[0]
+    const materialTypeLabel = materials.find(
+      ({ slug }) => slug === materialType,
+    )?.label
 
     if (!materialTypeLabel) {
       return
@@ -148,7 +133,9 @@ export function Calculator() {
     }
 
     for (const [material, amount] of preset.resources) {
-      const materialLabel = materials.find(([, b]) => b === material)?.[0]
+      const materialLabel = materials.find(
+        ({ slug }) => slug === material,
+      )?.label
 
       if (!materialLabel) {
         return

--- a/src/pages/calculator/calculator.tsx
+++ b/src/pages/calculator/calculator.tsx
@@ -65,11 +65,11 @@ export function Calculator() {
   // Hotkey handling for material type selection
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      // Only handle hotkeys when not typing in input fields
+      // Only handle hotkeys when not typing in text input fields or textareas
       if (
-        event.target instanceof HTMLInputElement ||
         event.target instanceof HTMLTextAreaElement ||
-        event.target instanceof HTMLSelectElement
+        (event.target instanceof HTMLInputElement && 
+         event.target.type !== 'number')
       ) {
         return
       }

--- a/src/pages/repair/repair.tsx
+++ b/src/pages/repair/repair.tsx
@@ -38,7 +38,9 @@ export function Repair() {
 
   const results = useMemo(() => {
     return repairMaterials.map((material) => {
-      const materialLabel = materials.find(([, b]) => b === material)?.[0]
+      const materialLabel = materials.find(
+        ({ slug }) => slug === material,
+      )?.label
 
       return [
         materialLabel,

--- a/src/utils/materials-math.ts
+++ b/src/utils/materials-math.ts
@@ -3,15 +3,15 @@ import type { RequirementItem, ResourceItem } from '../types'
 const chunks = [20, 16, 12, 8, 4, 2, 1] as const
 
 export const materials = [
-  ['Ceramics', 'ceramics'],
-  ['Chemicals', 'chemicals'],
-  ['Chiral Crystals', 'chiral_crystals'],
-  ['Metals', 'metals'],
-  ['Resins', 'resins'],
-  ['Special Alloys', 'special_alloys'],
+  { label: 'Ceramics', slug: 'ceramics', hotkey: 'c' },
+  { label: 'Chemicals', slug: 'chemicals', hotkey: 'h' },
+  { label: 'Chiral Crystals', slug: 'chiral_crystals', hotkey: 'i' },
+  { label: 'Metals', slug: 'metals', hotkey: 'm' },
+  { label: 'Resins', slug: 'resins', hotkey: 'r' },
+  { label: 'Special Alloys', slug: 'special_alloys', hotkey: 's' },
 ] as const
 
-export type Material = (typeof materials)[number][1]
+export type Material = (typeof materials)[number]['slug']
 
 export interface Structure {
   name: string


### PR DESCRIPTION
Add hotkeys for quickly selecting different material types. Also shows the keys in the dropdown and "How to use" help text.

![image](https://github.com/user-attachments/assets/132e29c7-fb9c-4c8e-bd86-844bed154a7b)

Open to suggestions on the actual hotkeys.